### PR TITLE
risc0-zkvm: add accelerator support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 crunchy = "0.2.2"
+risc0-zkvm = { path = "../risc0/risc0/zkvm", default-features = false }
 
 [profile.dev]
 opt-level = 3  # Controls the --opt-level the compiler builds with

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 crunchy = "0.2.2"
-risc0-zkvm = { path = "../risc0/risc0/zkvm", default-features = false }
+risc0-zkvm-platform = { path = "../risc0/risc0/zkvm/platform", default-features = false, features = ["export-syscalls"] }
 
 [profile.dev]
 opt-level = 3  # Controls the --opt-level the compiler builds with

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,10 @@ crunchy = "0.2.2"
 
 # note: branch named is used instead of rev as temporary measure to facilitate testing
 [target.'cfg(target_os = "zkvm")'.dependencies]
-risc0-zkvm-platform = { git = "https://github.com/risc0/risc0.git", branch = "erik/keccak-plumbing", default-features = false, features = ["export-syscalls"] }
-risc0-zkvm = { git = "https://github.com/risc0/risc0.git", branch = "erik/keccak-plumbing", default-features = false, feature = ["std"] }
+risc0-zkvm-platform = { git = "https://github.com/risc0/risc0.git", rev = "8b23b688e344d447c02cf608f66fd1f42756210e", default-features = false, features = ["export-syscalls"] }
+risc0-zkvm = { git = "https://github.com/risc0/risc0.git", rev = "8b23b688e344d447c02cf608f66fd1f42756210e", default-features = false }
+#risc0-zkvm-platform = { path = "../risc0/risc0/zkvm/platform", default-features = false, features = ["export-syscalls"] }
+#risc0-zkvm = { path = "../risc0/risc0/zkvm", default-features = false }
 
 [profile.dev]
 opt-level = 3  # Controls the --opt-level the compiler builds with

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,9 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 crunchy = "0.2.2"
-risc0-zkvm-platform = { path = "../risc0/risc0/zkvm/platform", default-features = false, features = ["export-syscalls"] }
-risc0-zkvm = { path = "../risc0/risc0/zkvm", default-features = false }
+# note: branch named is used instead of rev as temporary measure to facilitate testing
+risc0-zkvm-platform = { git = "https://github.com/risc0/risc0.git", branch = "erik/keccak-plumbing", default-features = false, features = ["export-syscalls"] }
+risc0-zkvm = { git = "https://github.com/risc0/risc0.git", branch = "erik/keccak-plumbing", default-features = false }
 
 [profile.dev]
 opt-level = 3  # Controls the --opt-level the compiler builds with

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,8 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 crunchy = "0.2.2"
 
-# note: branch named is used instead of rev as temporary measure to facilitate testing
 [target.'cfg(target_os = "zkvm")'.dependencies]
-risc0-zkvm-platform = { git = "https://github.com/risc0/risc0.git", rev = "8b23b688e344d447c02cf608f66fd1f42756210e", default-features = false, features = ["export-syscalls"] }
-risc0-zkvm = { git = "https://github.com/risc0/risc0.git", rev = "8b23b688e344d447c02cf608f66fd1f42756210e", default-features = false }
-#risc0-zkvm-platform = { path = "../risc0/risc0/zkvm/platform", default-features = false, features = ["export-syscalls"] }
-#risc0-zkvm = { path = "../risc0/risc0/zkvm", default-features = false }
+risc0-zkvm = { path = "../risc0/risc0/zkvm", default-features = false }
 
 [profile.dev]
 opt-level = 3  # Controls the --opt-level the compiler builds with

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["cryptography", "no-std"]
 [dependencies]
 crunchy = "0.2.2"
 risc0-zkvm-platform = { path = "../risc0/risc0/zkvm/platform", default-features = false, features = ["export-syscalls"] }
+risc0-zkvm = { path = "../risc0/risc0/zkvm", default-features = false }
 
 [profile.dev]
 opt-level = 3  # Controls the --opt-level the compiler builds with

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,11 @@ categories = ["cryptography", "no-std"]
 
 [dependencies]
 crunchy = "0.2.2"
+
 # note: branch named is used instead of rev as temporary measure to facilitate testing
+[target.'cfg(target_os = "zkvm")'.dependencies]
 risc0-zkvm-platform = { git = "https://github.com/risc0/risc0.git", branch = "erik/keccak-plumbing", default-features = false, features = ["export-syscalls"] }
-risc0-zkvm = { git = "https://github.com/risc0/risc0.git", branch = "erik/keccak-plumbing", default-features = false }
+risc0-zkvm = { git = "https://github.com/risc0/risc0.git", branch = "erik/keccak-plumbing", default-features = false, feature = ["std"] }
 
 [profile.dev]
 opt-level = 3  # Controls the --opt-level the compiler builds with

--- a/src/keccak.rs
+++ b/src/keccak.rs
@@ -1,7 +1,6 @@
 //! The `Keccak` hash functions.
 
 use super::{bits_to_rate, keccakf::KeccakF, Hasher, KeccakState};
-use risc0_zkvm::guest::env;
 
 /// The `Keccak` hash functions defined in [`Keccak SHA3 submission`].
 ///
@@ -71,7 +70,7 @@ impl Hasher for Keccak {
     /// # }
     /// ```
     fn update(&mut self, input: &[u8]) {
-        env::keccak_update(input);
+        self.state.update(input);
     }
 
     /// Pad and squeeze the state to the output.
@@ -89,6 +88,6 @@ impl Hasher for Keccak {
     /// #
     /// ```
     fn finalize(self, output: &mut [u8]) {
-        env::keccak_finalize(output);
+        self.state.finalize(output);
     }
 }

--- a/src/keccak.rs
+++ b/src/keccak.rs
@@ -1,6 +1,7 @@
 //! The `Keccak` hash functions.
 
 use super::{bits_to_rate, keccakf::KeccakF, Hasher, KeccakState};
+use risc0_zkvm::guest::env;
 
 /// The `Keccak` hash functions defined in [`Keccak SHA3 submission`].
 ///
@@ -70,7 +71,7 @@ impl Hasher for Keccak {
     /// # }
     /// ```
     fn update(&mut self, input: &[u8]) {
-        self.state.update(input);
+        env::keccak_update(input);
     }
 
     /// Pad and squeeze the state to the output.
@@ -88,6 +89,6 @@ impl Hasher for Keccak {
     /// #
     /// ```
     fn finalize(self, output: &mut [u8]) {
-        self.state.finalize(output);
+        env::keccak_finalize(output);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,6 +390,13 @@ impl<P> Clone for KeccakState<P> {
     }
 }
 
+impl<P> Drop for KeccakState<P> {
+    fn drop(&mut self) {
+        let status = unsafe { risc0_zkvm_platform::syscall::sys_keccak_close(self.fd)};
+        assert!(status == 0);
+    }
+}
+
 impl<P: Permutation> KeccakState<P> {
     fn new(rate: usize, delim: u8) -> Self {
         assert!(rate != 0, "rate cannot be equal 0");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 //! [`@oleganza`]: https://github.com/oleganza
 //! [`CC0`]: https://github.com/debris/tiny-keccak/blob/master/LICENSE
 
-//#![no_std]
+#![no_std]
 #![deny(missing_docs)]
 
 const RHO: [u32; 24] = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 //! [`@oleganza`]: https://github.com/oleganza
 //! [`CC0`]: https://github.com/debris/tiny-keccak/blob/master/LICENSE
 
-#![no_std]
+//#![no_std]
 #![deny(missing_docs)]
 
 const RHO: [u32; 24] = [

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -371,6 +371,7 @@ struct KeccakState<P> {
     rate: usize,
     delim: u8,
     mode: Mode,
+    fd: u32,
     permutation: core::marker::PhantomData<P>,
 }
 
@@ -382,6 +383,7 @@ impl<P> Clone for KeccakState<P> {
             rate: self.rate,
             delim: self.delim,
             mode: self.mode,
+            fd: self.fd,
             permutation: core::marker::PhantomData,
         }
     }
@@ -390,12 +392,16 @@ impl<P> Clone for KeccakState<P> {
 impl<P: Permutation> KeccakState<P> {
     fn new(rate: usize, delim: u8) -> Self {
         assert!(rate != 0, "rate cannot be equal 0");
+        let mut fd: u32 = 0;
+        let status = unsafe { risc0_zkvm_platform::syscall::sys_keccak_open(&mut fd as *mut u32)};
+        assert!(status == 0);
         KeccakState {
             buffer: Buffer::default(),
             offset: 0,
             rate,
             delim,
             mode: Mode::Absorbing,
+            fd,
             permutation: core::marker::PhantomData,
         }
     }


### PR DESCRIPTION
This a first draft of patching tiny keccak for risc0 accelerator support. We may want to guard these changes with cfg target_os = zkvm and we need to think of ways to support concurrent hashers but mostly opening for visibility. Placing in draft for now as it depends on my local version of risc0-zkvm. Once changes to risc0-zkvm is merged, I can point risc0 to a git dep, once we release, we can point risc0-zkvm dep to a released version.