### PR TITLE
bump risc0-zkvm version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography", "no-std"]
 crunchy = "0.2.2"
 
 [target.'cfg(target_os = "zkvm")'.dependencies]
-risc0-zkvm = { git = "https://github.com/risc0/risc0", rev = "b33c13fd22f9a07afa11edc969c56aad22dcbd53", default-features = false, features = ["std", "unstable"]}
+risc0-zkvm = { git = "https://github.com/risc0/risc0", rev = "f74920596c745a8bb7e8a6f1dfdefb44d03ed06f", default-features = false, features = ["std", "unstable"]}
 
 [profile.dev]
 opt-level = 3  # Controls the --opt-level the compiler builds with


### PR DESCRIPTION
this PR updates the risc0 reference to use configurable keccak po2. in the near future, we'll try using externs to avoid constantly updating tiny_keccak