### PR TITLE
bump to enable po2=18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["cryptography", "no-std"]
 crunchy = "0.2.2"
 
 [target.'cfg(target_os = "zkvm")'.dependencies]
-risc0-zkvm = { git = "https://github.com/risc0/risc0", rev = "f74920596c745a8bb7e8a6f1dfdefb44d03ed06f", default-features = false, features = ["std", "unstable"]}
+risc0-zkvm = { git = "https://github.com/risc0/risc0", rev = "8801e2e3cd030acea2f03f01bd91f37e47e79e23", default-features = false, features = ["std", "unstable"]}
 
 [profile.dev]
 opt-level = 3  # Controls the --opt-level the compiler builds with


### PR DESCRIPTION
TODO: figure out how to drop risc0 dependency while making it easy to test using `cargo risczero test`